### PR TITLE
Added integers to allowed values for number enums

### DIFF
--- a/src/openai_token_counter/models.py
+++ b/src/openai_token_counter/models.py
@@ -20,7 +20,7 @@ class NumberProp(BaseModel):
     description: Optional[str] = None
     minimum: Optional[int] = None
     maximum: Optional[int] = None
-    enum: Optional[list[str]] = None
+    enum: Optional[list[str | int]] = None
 
 
 class BoolProp(BaseModel):


### PR DESCRIPTION
Using integers as enum values is actually possible. 
For example:

```python
functions = [
    {
        "name": "get_current_temperature",
        "description": "Get the current temperature for a location",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {
                    "type": "string",
                    "description": "The location (e.g. city, country) to get the temperature",
                },
                "scale": {
                    "type": "number",
                    "enum": [1, 2], # HERE: can use integers
                    "description": "Use 1 for Celsius or 2 for Fahrenheit",
                },
            },
            "required": ["location", "scale"],
        },
    }
]
```