### PR TITLE
Tiktoken dependency change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openai-token-counter"
-version = "1.0.2"
+version = "1.0.3"
 description = "OpenAI Token Counter"
 authors = ["Eitan Nargassi <eitan@nyno.ai>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ Changelog = "https://github.com/Eitan1112/openai-token-counter/releases"
 [tool.poetry.dependencies]
 python = "^3.9"
 pydantic = "^2.3.0"
-tiktoken = "^0.5.1"
+tiktoken = "^0"
 
 [tool.poetry.group.dev.dependencies]
 Pygments = "^2.16.1"


### PR DESCRIPTION
The idea is to loosen the tiktoken dependency version requirement, mainly to enable usage with the newly released 0.7.0 which supports GPT-4o.